### PR TITLE
Literals syntax / values

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,10 +12,13 @@ pub enum Error<'a> {
     Parser(String),
 
     #[error("Invalid cell name: {0}")]
-    InvalidCellName(&'a str),
+    InvalidCellName(String),
 
     #[error("Invalid expression: {0}")]
     InvalidExpression(&'a str),
+
+    #[error("Not a number: {0}")]
+    InvalidNumericLiteral(String),
 
     #[error("Circular dependency detected: {0}")]
     CyclicDependency(&'a str),


### PR DESCRIPTION
An alternative to #5.

Pushes the literals out of the lexer and parser.

Handles values by returning `String` instead of `f64`.

TODO:

- ~~Return `Error` on `get_cell` parsing erros~~. (done)
- Better support for literals vs. formula syntax errors. (a big issue with no clear solution)
- Evaluate supporting and returning a `Value` type. (will do)
- ~~Choose between this design and #5 (literals inside the parser)~~. (this seems better / simpler)